### PR TITLE
declare all_mechanism in main to avoid NameError

### DIFF
--- a/SPFlatten.py
+++ b/SPFlatten.py
@@ -18,6 +18,8 @@ spf_ip_list = []
 spf_nonflat_mechanisms = []
 
 def main():
+   global all_mechanism
+   all_mechanism = ""
    flatten_spf(root_domain)
 
    dedupe_spf_ip_list = list(set(spf_ip_list))
@@ -57,7 +59,6 @@ def flatten_spf(domain):
 
 # Parse the given mechansim, and dispatch it accordintly
 def parse_mechanism(mechanism, domain):
-   global all_mechanism
    if re.match(r'^a$', mechanism):
       convert_domain_to_ipv4(domain)
    elif re.match(r'^mx$', mechanism):


### PR DESCRIPTION
Some spf declarations don't seem to have .all so you get the following error:
Traceback (most recent call last):
  File "spf", line 133, in <module>
    if __name__ == "__main__": main()
  File "spf", line 36, in main
    flat_spf += all_mechanism
NameError: global name 'all_mechanism' is not defined